### PR TITLE
VPC ID to be passed in and change the way searching of relevant subnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ Module usage:
 | storage_type | One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD). | `gp2` | no |
 | subnet_role | A role used to filter out which subnets the RDS should reside, defaults to Role=compute | `compute` | no |
 | tags | A map of tags to add to all resources | `<map>` | no |
-
+| vpc_id | The VPC ID to create the resources within | - | yes |

--- a/main.tf
+++ b/main.tf
@@ -31,17 +31,10 @@
  *
  */
 
-# Get the VPC for this instance, we use the environment tag
-data "aws_vpc" "selected" {
-  tags {
-    Env = "${var.environment}"
-  }
-}
-
 # Get a list of subnets the RDS should reside
 data "aws_subnet_ids" "selected" {
-  vpc_id = "${data.aws_vpc.selected.id}"
-  tags   = "${merge(map("Role", var.subnet_role), map("Env", var.environment))}"
+  vpc_id = "${var.vpc_id}"
+  tags   = "${var.subnet_tags}"
 }
 
 # Get the hosting zone
@@ -53,7 +46,7 @@ data "aws_route53_zone" "selected" {
 resource "aws_security_group" "db" {
   name        = "${var.identifier}-sg-rds"
   description = "The security group used to manage access to rds: ${var.identifier}, environment: ${var.environment}"
-  vpc_id      = "${data.aws_vpc.selected.id}"
+  vpc_id      = "${var.vpc_id}"
 
   tags = "${merge(var.tags, map("Name", format("%s-%s", var.environment, var.identifier)), map("Env", var.environment), map("KubernetesCluster", var.environment))}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -153,3 +153,7 @@ variable "tags" {
   description = "A map of tags to add to all resources"
   default     = {}
 }
+
+variable "vpc_id" {
+  description = "The VPC ID to create the resources within"
+ }


### PR DESCRIPTION
Current implementation cannot find subnet IDs for prod:
```
Error refreshing state: 1 error(s) occurred:
* module.*.data.aws_subnet_ids.selected: 1 error(s) occurred:
* module.*.data.aws_subnet_ids.selected: data.aws_subnet_ids.selected: no matching subnet found for vpc with id vpc-xxxx
[error] terraform operation: plan failed
```