### PR TITLE
Aurora updates

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -162,7 +162,7 @@ resource "aws_rds_cluster" "aurora_cluster" {
 
   backup_retention_period         = "${var.backup_retention_period}"
   cluster_identifier              = "${var.name}"
-  database_name                   = "${var.name}"
+  database_name                   = "${var.database_name}"
   db_cluster_parameter_group_name = "${aws_rds_cluster_parameter_group.db.id}"
   db_subnet_group_name            = "${local.db_subnet_group_name}"
   engine                          = "${var.engine_type}"

--- a/main.tf
+++ b/main.tf
@@ -186,7 +186,6 @@ resource "aws_rds_cluster_instance" "aurora_cluster_instance" {
   db_subnet_group_name       = "${local.db_subnet_group_name}"
   db_parameter_group_name    = "${aws_db_parameter_group.db.id}"
   engine                     = "${var.engine_type}"
-  engine_version             = "${var.engine_version}"
   identifier                 = "${var.name}${var.number_of_aurora_instances != 1 ? "-${count.index}" : "" }"
   instance_class             = "${var.instance_class}"
   publicly_accessible        = "${var.publicly_accessible}"


### PR DESCRIPTION
`engine_version` being removed from the `aurora_cluster_instance` resource to support Aurora cluster minor updates without re-creating the DB (some info about this [here](https://github.com/terraform-providers/terraform-provider-aws/pull/5010))

`database_name` in aurora_cluster being changed to reference `var.database_name` instead of `var.name` because allows the cluster identifier to be different from the db name if needed