### PR TITLE
use dbi_resource_id to specify aurora cluster in PI policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -75,7 +75,7 @@ locals {
     aws_db_instance.db_including_name.*.resource_id,
     aws_db_instance.db_read_replica.*.resource_id,
     aws_db_instance.db_excluding_name.*.resource_id,
-    aws_rds_cluster_instance.aurora_cluster_instance.*.resource_id,
+    aws_rds_cluster_instance.aurora_cluster_instance.*.dbi_resource_id,
   )), [""]), 0)
 }
 


### PR DESCRIPTION
@jdial1996 encountered: https://drone-gl.acp.homeoffice.gov.uk/acp/acp-notprod-resources/5778/1/2
which was [caused by resource_id](https://github.com/UKHomeOffice/acp-tf-rds/commit/72a37413dbe355525edd6235c14325f8b8be5696#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbR78) not being an attribute of [rds_cluster_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_instance) unlike for [db_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance)

=> needs to be updated to dbi_resource_id