### PR TITLE
amend 'log_access_enabled' policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -405,7 +405,10 @@ resource "aws_iam_policy" "rds_log_policy" {
         "rds:DescribeDBLogFiles",
         "rds:DownloadDBLogFilePortion"
       ],
-      "Resource": "${local.rds_instance_arn}"
+      "Resource": [
+        "${local.rds_instance_arn}",
+        "${local.rds_instance_arn}-*"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Aurora RDS clusters had no log access to replica instances due to the "-x" suffix. Policy change enables log access