### PR TITLE
ACPENG-2476 Allow Oracle charset to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ For an RDS instance with `storage_type` using `gp3`, be aware that `iops` cannot
 | <a name="input_database_password"></a> [database\_password](#input\_database\_password) | The default password for the specified user for RDS | `any` | n/a | yes |
 | <a name="input_database_port"></a> [database\_port](#input\_database\_port) | The database port being used by the RDS instance, i.e. 3306, 5342 | `any` | n/a | yes |
 | <a name="input_database_user"></a> [database\_user](#input\_database\_user) | The username for the RDS to be created | `string` | `"root"` | no |
+| <a name="input_db_character_set"></a> [db\_character\_set](#input\_db\_character\_set) | Character set name to use for DB encoding in Oracle/MSSQL | `string` | `null` | no |
+| <a name="input_db_character_set_nchar"></a> [db\_character\_set\_nchar](#input\_db\_character\_set\_nchar) | National character set name to use for DB encoding in Oracle/MSSQL | `string` | `null` | no |
 | <a name="input_db_cluster_parameter_family"></a> [db\_cluster\_parameter\_family](#input\_db\_cluster\_parameter\_family) | Cluster parameter group, depends on DB engine used | `string` | `""` | no |
 | <a name="input_db_cluster_parameters"></a> [db\_cluster\_parameters](#input\_db\_cluster\_parameters) | A map of database parameters for the RDS Cluster instance | `list(map(string))` | `[]` | no |
 | <a name="input_db_parameter_family"></a> [db\_parameter\_family](#input\_db\_parameter\_family) | Parameter group, depends on DB engine used | `any` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -97,6 +97,8 @@ resource "aws_db_instance" "db_including_name" {
   backup_window                         = var.backup_window
   copy_tags_to_snapshot                 = var.copy_tags_to_snapshot
   db_subnet_group_name                  = local.db_subnet_group_name
+  character_set_name                    = var.db_character_set
+  nchar_character_set_name              = var.db_character_set_nchar
   enabled_cloudwatch_logs_exports       = var.enabled_cloudwatch_logs_exports
   engine                                = var.engine_type
   engine_version                        = var.engine_version

--- a/variables.tf
+++ b/variables.tf
@@ -285,3 +285,17 @@ variable "deletion_protection" {
   type        = bool
   default     = false
 }
+
+variable "db_character_set" {
+  # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.OracleCharacterSets.html
+  description = "Character set name to use for DB encoding in Oracle/MSSQL"
+  type        = string
+  default     = null
+}
+
+variable "db_character_set_nchar" {
+  # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.OracleCharacterSets.html
+  description = "National character set name to use for DB encoding in Oracle/MSSQL"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
This adds a new argument to the module to permit two Oracle (and MSSQL) fields to be overridden from the defaults.

I overengineered this earlier in development by writing something like:
```terraform
  startswith(var.engine_type, "oracle") ? var.db_character_set : null
```
However, that proved unnecessary as you can just default the variable to be `null` unless specified. If it's Oracle and the variable is unset, it'll simply pick the default from upstream; if MySQL/Postgres and the variable is unset, upstream just ignores it as it's null.