### PR TITLE
Make gp3 the default for new RDS instances

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -93,7 +93,7 @@ variable "license_model" {
 
 variable "storage_type" {
   description = "One of 'standard' (magnetic), 'gp2' (general purpose SSD), 'gp3' (new generation of general purpose SSD), or 'io1' (provisioned IOPS SSD)."
-  default     = "gp2"
+  default     = "gp3"
 }
 
 variable "storage_encrypted" {


### PR DESCRIPTION
Compared to gp2, gp3 storage has improved performance and better cost efficiency: it's always cheaper to use gp3 rather than gp2.

This commit opts all managed resources into gp3 by default. If you're upgrading a module use to this version and beyond but wish to keep gp2, explicitly state `storage_class = "gp2"` in your configuration.