### PR TITLE
Set null provisioned IOPS if gp3 and low storage

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -46,10 +46,10 @@ locals {
       var.iops,
       // if MSSQL always return 3000
       substr(var.engine_type, 0, 9) == "sqlserver" ? 3000 : null,
-      // if Oracle return 3000 if less than 200GiB else 12000
-      substr(var.engine_type, 0, 6) == "oracle" ? var.allocated_storage >= 200 ? 12000 : 3000 : null,
-      // otherwise return 3000 if less than 400GiB else 12000
-      var.allocated_storage >= 400 ? 12000 : 3000
+      // if Oracle return 12000 if more than 200GiB
+      substr(var.engine_type, 0, 6) == "oracle" ? var.allocated_storage >= 200 ? 12000 : null : null,
+      // otherwise return 12000 if more than 400GiB
+      var.allocated_storage >= 400 ? 12000 : null
     )
   , null) : var.iops // if no option matches, return null; if not gp3, return var.iops
 }

--- a/main.tf
+++ b/main.tf
@@ -175,6 +175,7 @@ resource "aws_db_instance" "db_read_replica" {
   snapshot_identifier                   = var.snapshot_identifier
   storage_encrypted                     = var.storage_encrypted
   storage_type                          = var.storage_type
+  iops                                  = local.iops
   performance_insights_enabled          = var.performance_insights_enabled
   performance_insights_retention_period = var.performance_insights_retention_period
   ca_cert_identifier                    = var.ca_cert_identifier
@@ -221,6 +222,7 @@ resource "aws_db_instance" "db_excluding_name" {
   snapshot_identifier                   = var.snapshot_identifier
   storage_encrypted                     = var.storage_encrypted
   storage_type                          = var.storage_type
+  iops                                  = local.iops
   username                              = var.database_user
   performance_insights_enabled          = var.performance_insights_enabled
   performance_insights_retention_period = var.performance_insights_retention_period


### PR DESCRIPTION
In the previous version of this module, setting the storage class to gp3 on a small amount of provisioned storage defaulted to 3000, which is the baseline amount:

https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html#gp3-storage

Unfortunately, if the provisioned storage is less than 400 GiB AWS will not accept 3000 as the value and will instead error:

> Error modifying DB Instance foobar:
> InvalidParameterCombination:
> You can't specify IOPS or storage throughput for engine postgres
> and a storage size less than 400.

It transpires you can set the IOPS to 12000 as expected when using 400GiB or more, but for lower amounts of storage you're meant to not set the provisioned IOPS at all, even though there is an IOPS value (3000).

(For Oracle the threshold is 200GiB rather than 400GiB.)