### PR TITLE
Fix prefix

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -10,7 +10,7 @@ platform:
 steps:
 - name: validate
   pull: if-not-exists
-  image: quay.io/ukhomeofficedigital/terraform-toolset:v1.1.3-2
+  image: quay.io/ukhomeofficedigital/terraform-toolset:v1.12.2
   commands:
   - /acp/scripts/tf-validate.sh
   when:

--- a/README.md
+++ b/README.md
@@ -25,26 +25,26 @@ Module usage:
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0, < 5.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 4.67.0 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_self_serve_access_keys"></a> [self\_serve\_access\_keys](#module\_self\_serve\_access\_keys) | git::https://github.com/UKHomeOffice/acp-tf-self-serve-access-keys | v0.2.0 |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_db_instance.db_excluding_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance) | resource |
 | [aws_db_instance.db_including_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance) | resource |
 | [aws_db_instance.db_read_replica](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance) | resource |
@@ -73,7 +73,7 @@ Module usage:
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_allocated_storage"></a> [allocated\_storage](#input\_allocated\_storage) | The allocated storage in GBs for the RDS | `any` | n/a | yes |
 | <a name="input_allow_major_version_upgrade"></a> [allow\_major\_version\_upgrade](#input\_allow\_major\_version\_upgrade) | Allow major version upgrade | `bool` | `false` | no |
 | <a name="input_apply_immediately"></a> [apply\_immediately](#input\_apply\_immediately) | Specifies whether any database modifications are applied immediately | `bool` | `false` | no |
@@ -81,7 +81,7 @@ Module usage:
 | <a name="input_backup_retention_period"></a> [backup\_retention\_period](#input\_backup\_retention\_period) | How long will we retain backups | `string` | `7` | no |
 | <a name="input_backup_window"></a> [backup\_window](#input\_backup\_window) | When AWS can run snapshot, can't overlap with maintenance window | `string` | `"22:00-03:00"` | no |
 | <a name="input_ca_cert_identifier"></a> [ca\_cert\_identifier](#input\_ca\_cert\_identifier) | Specifies the identifier of the CA certificate for the DB | `string` | `"rds-ca-rsa2048-g1"` | no |
-| <a name="input_cidr_blocks"></a> [cidr\_blocks](#input\_cidr\_blocks) | A list of network cidr block which are permitted acccess | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| <a name="input_cidr_blocks"></a> [cidr\_blocks](#input\_cidr\_blocks) | A list of network cidr block which are permitted acccess | `list(string)` | <pre>[<br/>  "0.0.0.0/0"<br/>]</pre> | no |
 | <a name="input_copy_tags_to_snapshot"></a> [copy\_tags\_to\_snapshot](#input\_copy\_tags\_to\_snapshot) | Copy tags from DB to a snapshot | `bool` | `true` | no |
 | <a name="input_custom_option_group_name"></a> [custom\_option\_group\_name](#input\_custom\_option\_group\_name) | Name of custom option group for RDS instance | `string` | `""` | no |
 | <a name="input_database_name"></a> [database\_name](#input\_database\_name) | The name of the database to create | `string` | `""` | no |
@@ -132,7 +132,7 @@ Module usage:
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_db_excluding_name_instance_id"></a> [db\_excluding\_name\_instance\_id](#output\_db\_excluding\_name\_instance\_id) | ID of the instance |
 | <a name="output_db_including_name_instance_id"></a> [db\_including\_name\_instance\_id](#output\_db\_including\_name\_instance\_id) | ID of the instance |
 | <a name="output_rds_security_group_id"></a> [rds\_security\_group\_id](#output\_rds\_security\_group\_id) | ID of security group |

--- a/README.md
+++ b/README.md
@@ -25,26 +25,26 @@ Module usage:
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0, < 5.0 |
 
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 4.67.0 |
 
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_self_serve_access_keys"></a> [self\_serve\_access\_keys](#module\_self\_serve\_access\_keys) | git::https://github.com/UKHomeOffice/acp-tf-self-serve-access-keys | v0.2.0 |
 
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [aws_db_instance.db_excluding_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance) | resource |
 | [aws_db_instance.db_including_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance) | resource |
 | [aws_db_instance.db_read_replica](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance) | resource |
@@ -73,7 +73,7 @@ Module usage:
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_allocated_storage"></a> [allocated\_storage](#input\_allocated\_storage) | The allocated storage in GBs for the RDS | `any` | n/a | yes |
 | <a name="input_allow_major_version_upgrade"></a> [allow\_major\_version\_upgrade](#input\_allow\_major\_version\_upgrade) | Allow major version upgrade | `bool` | `false` | no |
 | <a name="input_apply_immediately"></a> [apply\_immediately](#input\_apply\_immediately) | Specifies whether any database modifications are applied immediately | `bool` | `false` | no |
@@ -132,7 +132,7 @@ Module usage:
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_db_excluding_name_instance_id"></a> [db\_excluding\_name\_instance\_id](#output\_db\_excluding\_name\_instance\_id) | ID of the instance |
 | <a name="output_db_including_name_instance_id"></a> [db\_including\_name\_instance\_id](#output\_db\_including\_name\_instance\_id) | ID of the instance |
 | <a name="output_rds_security_group_id"></a> [rds\_security\_group\_id](#output\_rds\_security\_group\_id) | ID of security group |

--- a/main.tf
+++ b/main.tf
@@ -244,28 +244,28 @@ resource "aws_rds_cluster" "aurora_cluster" {
   # aurora = MySQL 5.6-compatible, aurora-mysql = MySQL 5.7-compatible
   count = var.engine_type == "aurora" || var.engine_type == "aurora-mysql" || var.engine_type == "aurora-postgresql" ? 1 : 0
 
-  allow_major_version_upgrade     = var.allow_major_version_upgrade
-  apply_immediately               = var.apply_immediately
+  allow_major_version_upgrade      = var.allow_major_version_upgrade
+  apply_immediately                = var.apply_immediately
   db_instance_parameter_group_name = var.allow_major_version_upgrade ? aws_db_parameter_group.db.id : null
-  backup_retention_period         = var.backup_retention_period
-  cluster_identifier              = var.name
-  database_name                   = var.database_name
-  db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.db[0].id
-  db_subnet_group_name            = local.db_subnet_group_name
-  enabled_cloudwatch_logs_exports = var.enabled_cloudwatch_logs_exports
-  engine                          = var.engine_type
-  engine_version                  = var.engine_version
-  final_snapshot_identifier       = var.name
-  master_password                 = var.database_password
-  master_username                 = var.database_user
-  port                            = var.database_port
-  preferred_backup_window         = var.backup_window
-  preferred_maintenance_window    = var.maintenance_window
-  skip_final_snapshot             = var.skip_final_snapshot
-  snapshot_identifier             = var.snapshot_identifier
-  storage_encrypted               = var.storage_encrypted
-  vpc_security_group_ids          = [aws_security_group.db.id]
-  deletion_protection             = var.deletion_protection
+  backup_retention_period          = var.backup_retention_period
+  cluster_identifier               = var.name
+  database_name                    = var.database_name
+  db_cluster_parameter_group_name  = aws_rds_cluster_parameter_group.db[0].id
+  db_subnet_group_name             = local.db_subnet_group_name
+  enabled_cloudwatch_logs_exports  = var.enabled_cloudwatch_logs_exports
+  engine                           = var.engine_type
+  engine_version                   = var.engine_version
+  final_snapshot_identifier        = var.name
+  master_password                  = var.database_password
+  master_username                  = var.database_user
+  port                             = var.database_port
+  preferred_backup_window          = var.backup_window
+  preferred_maintenance_window     = var.maintenance_window
+  skip_final_snapshot              = var.skip_final_snapshot
+  snapshot_identifier              = var.snapshot_identifier
+  storage_encrypted                = var.storage_encrypted
+  vpc_security_group_ids           = [aws_security_group.db.id]
+  deletion_protection              = var.deletion_protection
   tags = merge(
     var.tags,
     {

--- a/main.tf
+++ b/main.tf
@@ -305,7 +305,7 @@ resource "aws_rds_cluster_instance" "aurora_cluster_instance" {
 
 # Create the database parameters
 resource "aws_db_parameter_group" "db" {
-  name_prefix = "${var.name}-db-parameters-${var.db_parameter_family}-"
+  name_prefix = "${var.name}-db-parameters-${replace(var.db_parameter_family, ".", "-")}-"
 
   description = "Database Parameters Group for RDS: ${var.environment}.${var.name}"
   family      = var.db_parameter_family


### PR DESCRIPTION
This PR:

- updates the Drone pipeline to use a more recent Terraform version in line with other pipelines within the HO.
- santises the db_parameter_family var when interpolated into name_prefix to ensure there are no invalid chars.

According to Terraform, 'only lowercase alphanumeric characters and hyphens [are] allowed in parameter group "name_prefix"'. As such, typical values for "db_parameter_family" such as "mariadb10.6" would previously have generated an error.